### PR TITLE
Change default scope to use user_friends

### DIFF
--- a/src/facebook.js
+++ b/src/facebook.js
@@ -15,7 +15,7 @@ class FacebookLogin extends React.Component {
 
   static defaultProps = {
     textButton: 'Login with Facebook',
-    scope: 'public_profile, email, user_birthday',
+    scope: 'public_profile, email, user_friends',
     xfbml: false,
     size: 'medium',
   };

--- a/src/facebook.js
+++ b/src/facebook.js
@@ -15,7 +15,7 @@ class FacebookLogin extends React.Component {
 
   static defaultProps = {
     textButton: 'Login with Facebook',
-    scope: 'public_profile, email, user_friends',
+    scope: 'public_profile, email',
     xfbml: false,
     size: 'medium',
   };


### PR DESCRIPTION
`user_friends` is available for a Facebook app by default. `user_birthday` the app needs to go through review process.