### PR TITLE
Use typeButton prop

### DIFF
--- a/src/facebook.js
+++ b/src/facebook.js
@@ -184,7 +184,7 @@ class FacebookLogin extends React.Component {
   }
 
   render() {
-    const { cssClass, size, icon, textButton, buttonStyle } = this.props;
+    const { cssClass, size, icon, textButton, typeButton, buttonStyle } = this.props;
     const isIconString = typeof icon === 'string';
     return (
       <span style={ this.containerStyle() }>
@@ -195,6 +195,7 @@ class FacebookLogin extends React.Component {
           />
         )}
         <button
+          type={typeButton}
           className={`${cssClass} ${size}`}
           style={ buttonStyle }
           onClick={this.click}


### PR DESCRIPTION
The typeButton property is presently unused. This is problematic because a type-less button turns into a submit button when inside a form.