### PR TITLE
adds babel plugin 'transform-object-assign' for better IE11 support (fixes #108)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,13 +26,12 @@
   },
   "homepage": "https://github.com/keppelen/react-facebook-login",
   "devDependencies": {
-    "react": "^15.1.0",
-    "react-dom": "^15.1.0",
     "autoprefixer": "^6.0.3",
     "babel": "^6.5.2",
     "babel-core": "^6.6.5",
     "babel-eslint": "^4.1.6",
     "babel-loader": "^6.2.4",
+    "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-react": "^6.1.18",
     "babel-preset-stage-0": "^6.5.0",
@@ -42,11 +41,13 @@
     "eslint-plugin-react": "^3.11.3",
     "node-sass": "^3.3.x",
     "postcss-loader": "^0.6.0",
+    "react": "^15.1.0",
     "react-addons-test-utils": "^15.1.0",
     "react-css-modules": "^3.5.0",
+    "react-dom": "^15.1.0",
+    "react-router": "^3.0.0",
     "sass-loader": "^3.0.0",
     "style-loader": "0.12.x",
-    "react-router": "^3.0.0",
     "webpack": "1.12.x",
     "webpack-dev-server": "1.12.x"
   },
@@ -58,6 +59,7 @@
       "es2015",
       "react",
       "stage-0"
-    ]
+    ],
+    "plugins": ["transform-object-assign"]
   }
 }


### PR DESCRIPTION
PR adds this babel plugin to the build process: https://babeljs.io/docs/plugins/transform-object-assign/ to be compatible with browsers that don't support Object.assign (http://kangax.github.io/compat-table/es6/#test-Object_static_methods_Object.assign).

I haven't included a newly built distribution bundle, but if you want, I can add that to the PR.