### PR TITLE
Migrating from React.PropTypes to prop-types package from Facebook

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-plugin-react": "^3.11.3",
     "node-sass": "^3.3.x",
     "postcss-loader": "^0.6.0",
+    "prop-types": "^15.5.8",
     "react": "^15.1.0",
     "react-addons-test-utils": "^15.1.0",
     "react-css-modules": "^3.5.0",

--- a/src/facebook.js
+++ b/src/facebook.js
@@ -1,5 +1,6 @@
 // @flow
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import styles from '../styles/facebook.scss';
 import objectToParams from './objectToParams';
 


### PR DESCRIPTION
This pull requests migrates from React.PropTypes to prop-types package from Facebook so that there is no longer a console error thrown when using React 15.5+.

More details here: https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html