### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ export default MyComponent;
 |   callback   |     function        |             resultFacebookLogin                     |
 |   autoLoad   |     boolean         |                  false                              |
 |     xfbml    |     boolean         |                  false                              |
+|    cookie    |     boolean         |                  false                              |
 |reAuthenticate|     boolean         |                  false                              |
 |   textButton |     string          |           Login with Facebook                       |
 |   cssClass   |     string          | kep-login-facebook kep-login-facebook-[button-size] |


### PR DESCRIPTION
This component can receive `cookie` parameter in FB JavaScript SDK.
So it should show in readme.