### PR TITLE
optionally run onFailure to separate failed attempts

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ see https://developers.facebook.com/docs/facebook-login/permissions for permissi
       )
     }
   }
-  
+
   export default MyComponent;
 ```
 
@@ -170,3 +170,4 @@ export default MyComponent;
 |   onClick    |     function        |                  Initial click on the component     |
 |   isMobile   |     boolean         |                  detected via userAgent             |
 |     tag      |     string          |                  HTML Element, Ex: 'a', 'button'             |
+|   onFailure  |     function        | optional function to separatere the failed init     |

--- a/src/facebook.js
+++ b/src/facebook.js
@@ -53,6 +53,7 @@ class FacebookLogin extends React.Component {
     containerStyle: PropTypes.object,
     buttonStyle: PropTypes.object,
     tag: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+    onFailure: PropTypes.func,
   };
 
   static defaultProps = {
@@ -71,6 +72,7 @@ class FacebookLogin extends React.Component {
     disableMobileRedirect: false,
     isMobile: getIsMobile(),
     tag: 'button',
+    onFailure: null,
   };
 
   state = {
@@ -149,7 +151,9 @@ class FacebookLogin extends React.Component {
     if (response.authResponse) {
       this.responseApi(response.authResponse);
     } else {
-      if (this.props.callback) {
+      if (this.props.onFailure) {
+        this.props.onFailure({ status: response.status });
+      } else {
         this.props.callback({ status: response.status });
       }
     }


### PR DESCRIPTION
Optionally users can add a `onFailure` callback to separate the failed attempts/init. If `null` or left undefined the original flow will be respected.

+ edited the README.