### PR TITLE
Updated peerDependencies to support React 16 without warning.

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "webpack-dev-server": "1.12.x"
   },
   "peerDependencies": {
-    "react": "^15.1.0"
+    "react": "^15.0.0-0 || ^16.0.0-0"
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "node-sass": "^3.3.x",
     "postcss-loader": "^0.6.0",
     "prop-types": "^15.5.10",
-    "react": "^15.1.0",
+    "react": "^15.0.0-0 || ^16.0.0-0",
     "react-addons-test-utils": "^15.1.0",
     "react-css-modules": "^3.5.0",
     "react-dom": "^15.1.0",


### PR DESCRIPTION
In order to solve [#176](https://github.com/keppelen/react-facebook-login/issues/176) I changed the versioning for React in both `peerDependencies` and `devDependencies` to `15.0.0-0 || 16.0.0-0`.

Please, correct me if I'm wrong.