### PR TITLE
Update package.json version string to canonical 3.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-facebook-login",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "description": "A Component React for Facebook Login",
   "main": "dist/facebook-login.js",
   "scripts": {


### PR DESCRIPTION
The version string in package.json is still listed as '3.6.2', but the latest version available through npm/yarn is '3.7.0'. The 3.7.0 version includes the fix for React v16 peerDeps feedback during install. Trying to install @3.6.2 and getting peerDep errors during install is confusing when the git history clearly indicates that problem is fixed.