### PR TITLE
When checking PropTypes, don't use React.PropTypes

### DIFF
--- a/src/facebook.js
+++ b/src/facebook.js
@@ -53,7 +53,7 @@ class FacebookLogin extends React.Component {
     onClick: PropTypes.func,
     containerStyle: PropTypes.object,
     buttonStyle: PropTypes.object,
-    children: React.PropTypes.node,
+    children: PropTypes.node,
     tag: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
     onFailure: PropTypes.func,
   };


### PR DESCRIPTION
There was an instance of `React.PropTypes` left in the prop types, I assume by accident.
I have verified that `prop-types` has the `node` setting: https://github.com/facebook/prop-types#usage
This PR just removes the `React.` part of the prop type checking.