### PR TITLE
Support re-requesting permissions (#149)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ export default MyComponent;
 |     xfbml    |     boolean         |                  false                              |
 |    cookie    |     boolean         |                  false                              |
 |reAuthenticate|     boolean         |                  false                              |
+|   reRequest  |     boolean         |                  false                              |
 |   textButton |     string          |           Login with Facebook                       |
 |   cssClass   |     string          | kep-login-facebook kep-login-facebook-[button-size] |
 | redirectUri  |     string          |               window.location.href (mobile-only)    |

--- a/src/facebook.js
+++ b/src/facebook.js
@@ -36,6 +36,7 @@ class FacebookLogin extends React.Component {
     xfbml: PropTypes.bool,
     cookie: PropTypes.bool,
     reAuthenticate: PropTypes.bool,
+    reRequest: PropTypes.bool,
     scope: PropTypes.string,
     returnScopes: PropTypes.bool,
     redirectUri: PropTypes.string,
@@ -67,6 +68,7 @@ class FacebookLogin extends React.Component {
     xfbml: false,
     cookie: false,
     reAuthenticate: false,
+    reRequest: false,
     size: 'metro',
     fields: 'name',
     cssClass: 'kep-login-facebook',
@@ -180,7 +182,7 @@ class FacebookLogin extends React.Component {
       return;
     }
     this.setState({ isProcessing: true });
-    const { scope, appId, onClick, reAuthenticate, returnScopes, redirectUri, disableMobileRedirect } = this.props;
+    const { scope, appId, onClick, reAuthenticate, reRequest, returnScopes, redirectUri, disableMobileRedirect } = this.props;
 
     if (typeof onClick === 'function') {
       onClick(e);
@@ -199,6 +201,8 @@ class FacebookLogin extends React.Component {
 
     if (reAuthenticate) {
       params.auth_type = 'reauthenticate';
+    } else if (reRequest) {
+      params.auth_type = 'rerequest';
     }
 
     if (this.props.isMobile && !disableMobileRedirect) {


### PR DESCRIPTION
Adding support for re-requesting permissions.

Ideally we would have a single prop for selecting auth_type (since reAuthenticate and reRequest are mutually exclusive). I'm using the approach with second prop to stay backwards compatible.