### PR TITLE
Update facebook.js

### DIFF
--- a/src/facebook.js
+++ b/src/facebook.js
@@ -113,8 +113,8 @@ class FacebookLogin extends React.Component {
   isRedirectedFromFb() {
     const params = window.location.search;
     return (
-      decodeParamForKey(params, 'code') ||
-      decodeParamForKey(params, 'granted_scopes')
+      decodeParamForKey(params, 'state') === 'facebookdirect' && ( decodeParamForKey(params, 'code') ||
+      decodeParamForKey(params, 'granted_scopes') )
     );
   }
 

--- a/src/facebook.js
+++ b/src/facebook.js
@@ -113,8 +113,8 @@ class FacebookLogin extends React.Component {
   isRedirectedFromFb() {
     const params = window.location.search;
     return (
-      decodeParamForKey(params, 'state') === 'facebookdirect' && ( decodeParamForKey(params, 'code') ||
-      decodeParamForKey(params, 'granted_scopes') )
+      decodeParamForKey(params, 'state') === 'facebookdirect' && (decodeParamForKey(params, 'code') ||
+      decodeParamForKey(params, 'granted_scopes'))
     );
   }
 


### PR DESCRIPTION
Add determination of state which only comes from facebookdirect. The facebook.js can't recognize the url callback from different Social Login. 

I have tried to use different social login and `decodeParamForKey(params, 'code')`  in **facebook.js** will work on url even the response **code not comes from Facebook** and pop up the Facebook auth Login modal.

(For example, I used Line Login (Liff2) and it will also callback my app and the url return as below 

http://localhost:3000/login?code=some-code-from-line&liffClientId=some-id&state=some-state&liffRedirectUri=my-redirect-uri

and isRedirectedFromFb() excutes then break off the Line Login in my app)



