### PR TITLE
Remove extra `user_birthday` field

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ export default MyComponent;
 |:------------:|:-------------------:|:---------------------------------------------------:|
 |     appId    |     string          |                Required                             |
 |     size     |     string          |              small - medium - metro                 |
-|     scope    |     string          |      public_profile, email, user_birthday           |
+|     scope    |     string          |      public_profile, email          |
 |     fields   |     string          |              name,email,picture                     |
 |   callback   |     function        |             resultFacebookLogin                     |
 | returnScopes |     boolean         |                  false                              |


### PR DESCRIPTION
According to [this line](https://github.com/keppelen/react-facebook-login/blob/master/src/facebook.js#L46) in the code, there's no `user_birthday`!